### PR TITLE
Fix create_hook_api_ex target pointer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,13 +140,11 @@ impl MinHook {
 
     /// Extended function for creating a hook for the targeted API function and detours it to the detour function. This function returns the original function pointer as well as a pointer to the target function.
     /// # Safety
-    ///
-    /// TOOO: Revise if this is correct
     pub unsafe fn create_hook_api_ex<T: AsRef<str>>(
         module_name: T,
         proc_name: T,
         detour: *mut c_void,
-    ) -> Result<(*mut c_void, *mut *mut c_void), MH_STATUS> {
+    ) -> Result<(*mut c_void, *mut c_void), MH_STATUS> {
         Self::initialize();
 
         let mut module_name = module_name.as_ref().encode_utf16().collect::<Vec<_>>();
@@ -154,14 +152,14 @@ impl MinHook {
 
         let proc_name = CString::new(proc_name.as_ref()).unwrap();
         let mut pp_original: *mut c_void = null_mut();
-        let pp_target: *mut *mut c_void = null_mut();
+        let mut pp_target: *mut c_void = null_mut();
         let status = unsafe {
             MH_CreateHookApiEx(
                 module_name.as_ptr() as *const _,
                 proc_name.as_ptr() as *const _,
                 detour,
                 &mut pp_original,
-                pp_target,
+                &mut pp_target,
             )
         };
         debug!("MH_CreateHookApiEx: {:?}", status);

--- a/tests/create_hook_api_ex.rs
+++ b/tests/create_hook_api_ex.rs
@@ -12,8 +12,7 @@ fn test_create_hook_api_ex() {
         )
         .unwrap();
 
-        // The extended API must return the resolved target function instead of
-        // falling back to MinHook's null `MH_ALL_HOOKS` sentinel.
+        // Target should not be null, otherwise something is wrong
         assert!(!target.is_null());
 
         // Grab the current process id

--- a/tests/create_hook_api_ex.rs
+++ b/tests/create_hook_api_ex.rs
@@ -12,11 +12,15 @@ fn test_create_hook_api_ex() {
         )
         .unwrap();
 
+        // The extended API must return the resolved target function instead of
+        // falling back to MinHook's null `MH_ALL_HOOKS` sentinel.
+        assert!(!target.is_null());
+
         // Grab the current process id
         let original_pid = std::process::id();
 
         // Enable the hook
-        MinHook::enable_hook(target as _).unwrap();
+        MinHook::enable_hook(target).unwrap();
 
         // Call the Rust std library function to get the current process id
         // It should return the value we set in the hook `get_current_process_id_hook`
@@ -29,7 +33,10 @@ fn test_create_hook_api_ex() {
         assert_eq!(original_fn(), original_pid);
 
         // Disable the hook
-        MinHook::disable_hook(target as _).unwrap();
+        MinHook::disable_hook(target).unwrap();
+
+        // Remove the hook so this test leaves no process-global MinHook state behind.
+        MinHook::remove_hook(target).unwrap();
     }
 
     fn get_current_process_id_hook() -> u32 {


### PR DESCRIPTION
## What changed

- pass a writable target output slot to `MH_CreateHookApiEx`
- return the resolved target as `*mut c_void` instead of a pointer-to-pointer
- add a regression assertion that rejects the null `MH_ALL_HOOKS` sentinel
- disable and remove the specific hook during test cleanup

## Why

`create_hook_api_ex` previously initialized `pp_target` to null and passed that null pointer directly to MinHook. Because `ppTarget` is an optional output parameter, MinHook could not populate it, so the wrapper returned null. The existing test then passed that null value to `enable_hook`, which MinHook interprets as `MH_ALL_HOOKS`, masking the bug.

## Impact

Callers now receive the actual resolved API target and can enable, disable, or remove that specific hook. The corrected tuple element changes from `*mut *mut c_void` to `*mut c_void`, matching the underlying MinHook API's output value.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D clippy::all`
- `cargo test --all-targets`