### PR TITLE
Harden optimized hooks, Win32 ABI usage, and lifecycle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  lint:
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -19,5 +19,32 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D clippy::all
 
+  test:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+            profile: debug
+            flags: ""
+          - target: x86_64-pc-windows-msvc
+            profile: release
+            flags: --release
+          - target: i686-pc-windows-msvc
+            profile: debug
+            flags: ""
+          - target: i686-pc-windows-msvc
+            profile: release
+            flags: --release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --target ${{ matrix.target }}
+
       - name: Test
-        run: cargo test --all-targets
+        run: cargo test --all-targets --target ${{ matrix.target }} ${{ matrix.flags }}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ This example shows how to create a hook for a function, and also call the origin
 use minhook::{MinHook, MH_STATUS};
 
 fn main() -> Result<(), MH_STATUS> {
-    // Create a hook for the return_0 function, detouring it to return_1
+    // Keep calls indirect so optimized builds cannot bypass the patched entry point.
+    let return_0 = std::hint::black_box(return_0 as fn() -> i32);
+    let return_1 = std::hint::black_box(return_1 as fn() -> i32);
+
+    // Create a hook for the return_0 function, detouring it to return_1.
     let return_0_address = unsafe { MinHook::create_hook(return_0 as _, return_1 as _)? };
 
     // Enable the hook
@@ -49,14 +53,28 @@ fn main() -> Result<(), MH_STATUS> {
     Ok(())
 }
 
+#[inline(never)]
 fn return_0() -> i32 {
     0
 }
 
+#[inline(never)]
 fn return_1() -> i32 {
     1
 }
 ```
+
+Calls to functions defined in the same Rust crate can be optimized without going through the
+patched entry point. Keep such functions out of line and call them through an opaque function
+pointer, as the example does, when testing hooks in optimized builds.
+
+When hooking a Win32 API, the detour and trampoline must use the API's exact signature and calling
+convention. In most cases this means `unsafe extern "system" fn(...)`. This is especially important
+on 32-bit Windows, where the system ABI differs from Rust's native ABI.
+
+`MinHook::uninitialize` is unsafe because it can invalidate every trampoline allocated by the
+native library. Call it only after all detours and trampoline calls have stopped. The wrapper will
+not tear down a MinHook instance that it detected was initialized by another component.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,11 @@
 //! use minhook::{MinHook, MH_STATUS};
 //!
 //! fn main() -> Result<(), MH_STATUS> {
-//!     // Create a hook for the return_0 function, detouring it to return_1
+//!     // Keep calls indirect so optimized builds cannot bypass the patched entry point.
+//!     let return_0 = std::hint::black_box(return_0 as fn() -> i32);
+//!     let return_1 = std::hint::black_box(return_1 as fn() -> i32);
+//!
+//!     // Create a hook for the return_0 function, detouring it to return_1.
 //!     let return_0_address = unsafe { MinHook::create_hook(return_0 as _, return_1 as _)? };
 //!
 //!     // Enable the hook
@@ -28,10 +32,12 @@
 //!     Ok(())
 //! }
 //!
+//! #[inline(never)]
 //! fn return_0() -> i32 {
 //!     0
 //! }
 //!
+//! #[inline(never)]
 //! fn return_1() -> i32 {
 //!     1
 //! }
@@ -46,7 +52,7 @@ use std::{
     ffi::{CString, c_void},
     fmt,
     ptr::null_mut,
-    sync::Once,
+    sync::{Mutex, MutexGuard},
 };
 use tracing::debug;
 
@@ -54,50 +60,102 @@ mod ffi;
 
 const MH_ALL_HOOKS: *const i32 = std::ptr::null();
 
-static MINHOOK_INIT: Once = Once::new();
-static MINHOOK_UNINIT: Once = Once::new();
+#[derive(Debug)]
+struct MinHookState {
+    initialized: bool,
+    owned: bool,
+}
+
+static MINHOOK_STATE: Mutex<MinHookState> = Mutex::new(MinHookState {
+    initialized: false,
+    owned: false,
+});
 
 /// A struct to access the MinHook API.
 pub struct MinHook {}
 
 impl MinHook {
-    // Initialize MinHook
-    fn initialize() {
-        MINHOOK_INIT.call_once(|| {
-            let status = unsafe { MH_Initialize() };
-            debug!("MH_Initialize: {:?}", status);
-
-            match status.ok() {
-                Ok(_) => (), // Initialization successful, do nothing
-                Err(MH_STATUS::MH_ERROR_ALREADY_INITIALIZED) => (), // Ignore if already initialized
-                Err(e) => panic!("Could not initialize MinHook, error: {e:?}"),
-            }
-        });
+    fn state() -> MutexGuard<'static, MinHookState> {
+        MINHOOK_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    /// Uninitializes MinHook. This function is only possible to call once. If you want to reinitialize MinHook, you need to restart the program.
+    // Initialize MinHook and retain the state lock for the native operation that follows.
+    fn initialize() -> Result<MutexGuard<'static, MinHookState>, MH_STATUS> {
+        let mut state = Self::state();
+        if state.initialized {
+            return Ok(state);
+        }
+
+        let status = unsafe { MH_Initialize() };
+        debug!("MH_Initialize: {:?}", status);
+
+        match status {
+            MH_STATUS::MH_OK => {
+                state.initialized = true;
+                state.owned = true;
+                Ok(state)
+            }
+            MH_STATUS::MH_ERROR_ALREADY_INITIALIZED => {
+                // Another component owns the process-global MinHook instance. We can use it,
+                // but must not tear it down from `uninitialize`.
+                state.initialized = true;
+                state.owned = false;
+                Ok(state)
+            }
+            _ => Err(status),
+        }
+    }
+
+    /// Detaches this wrapper from MinHook and uninitializes the native library when this
+    /// wrapper initialized it.
+    ///
+    /// A later API call may initialize MinHook again. If MinHook was already initialized by
+    /// another component, this method only resets the wrapper's state and leaves the shared
+    /// native instance running.
     ///
     /// # Safety
-    pub fn uninitialize() {
-        // Make sure we are initialized before we uninitialize
-        Self::initialize();
+    ///
+    /// The caller must ensure that no thread is executing a detour or trampoline and that no
+    /// trampoline pointer returned by this crate will be called after this method succeeds.
+    /// All other users of the process-global MinHook instance must be synchronized with this
+    /// operation.
+    pub unsafe fn uninitialize() -> Result<(), MH_STATUS> {
+        let mut state = Self::state();
+        if !state.initialized {
+            return Err(MH_STATUS::MH_ERROR_NOT_INITIALIZED);
+        }
 
-        MINHOOK_UNINIT.call_once(|| {
-            let status = unsafe { MH_Uninitialize() };
-            debug!("MH_Uninitialize: {:?}", status);
+        if !state.owned {
+            state.initialized = false;
+            return Ok(());
+        }
 
-            status.ok().expect("Could not uninitialize MinHook");
-        });
+        let status = unsafe { MH_Uninitialize() };
+        debug!("MH_Uninitialize: {:?}", status);
+
+        if status == MH_STATUS::MH_OK {
+            state.initialized = false;
+            state.owned = false;
+        }
+
+        status.ok()
     }
 
     /// Creates a hook for the target function and detours it to the detour function. This function returns the original function pointer.
     ///
     /// # Safety
+    ///
+    /// `target` and `detour` must be valid executable function addresses with identical
+    /// signatures and calling conventions. Neither function may unwind across an incompatible
+    /// ABI boundary. The returned trampoline may only be called while the hook exists and
+    /// MinHook remains initialized.
     pub unsafe fn create_hook(
         target: *mut c_void,
         detour: *mut c_void,
     ) -> Result<*mut c_void, MH_STATUS> {
-        Self::initialize();
+        let _state = Self::initialize()?;
 
         let mut pp_original: *mut c_void = null_mut();
         let status = unsafe { MH_CreateHook(target, detour, &mut pp_original) };
@@ -111,12 +169,17 @@ impl MinHook {
     /// Creates a hook for the targeted API function and detours it to the detour function. This function returns the original function pointer.
     ///
     /// # Safety
+    ///
+    /// `detour` must have exactly the same signature and calling convention as the named API.
+    /// Win32 API detours should normally use `extern "system"`. The detour must not unwind across
+    /// the foreign ABI boundary. The returned trampoline may only be called while the hook exists
+    /// and MinHook remains initialized.
     pub unsafe fn create_hook_api<T: AsRef<str>>(
         module_name: T,
         proc_name: T,
         detour: *mut c_void,
     ) -> Result<*mut c_void, MH_STATUS> {
-        Self::initialize();
+        let _state = Self::initialize()?;
 
         let mut module_name = module_name.as_ref().encode_utf16().collect::<Vec<_>>();
         module_name.push(0);
@@ -140,12 +203,17 @@ impl MinHook {
 
     /// Extended function for creating a hook for the targeted API function and detours it to the detour function. This function returns the original function pointer as well as a pointer to the target function.
     /// # Safety
+    ///
+    /// `detour` must have exactly the same signature and calling convention as the named API.
+    /// Win32 API detours should normally use `extern "system"`. The detour must not unwind across
+    /// the foreign ABI boundary. The returned pointers remain valid only while the hook exists,
+    /// its module remains loaded, and MinHook remains initialized.
     pub unsafe fn create_hook_api_ex<T: AsRef<str>>(
         module_name: T,
         proc_name: T,
         detour: *mut c_void,
     ) -> Result<(*mut c_void, *mut c_void), MH_STATUS> {
-        Self::initialize();
+        let _state = Self::initialize()?;
 
         let mut module_name = module_name.as_ref().encode_utf16().collect::<Vec<_>>();
         module_name.push(0);
@@ -172,8 +240,11 @@ impl MinHook {
     /// Enables a hook for the target function.
     ///
     /// # Safety
+    ///
+    /// `target` must identify a hook created by MinHook. The caller must ensure that activating
+    /// the detour is sound for every thread that can call the target function.
     pub unsafe fn enable_hook(target: *mut c_void) -> Result<(), MH_STATUS> {
-        Self::initialize();
+        let _state = Self::initialize()?;
 
         let status = unsafe { MH_EnableHook(target) };
         debug!("MH_EnableHook: {:?}", status);
@@ -186,6 +257,9 @@ impl MinHook {
     /// Enables all hooks.
     ///
     /// # Safety
+    ///
+    /// The caller must ensure that activating every registered detour is sound for every thread
+    /// that can call the affected target functions.
     pub unsafe fn enable_all_hooks() -> Result<(), MH_STATUS> {
         unsafe { Self::enable_hook(MH_ALL_HOOKS as *mut _) }
     }
@@ -193,8 +267,11 @@ impl MinHook {
     /// Disables a hook for the target function.
     ///
     /// # Safety
+    ///
+    /// `target` must identify a hook created by MinHook. The caller must synchronize any code
+    /// that depends on whether the detour is active.
     pub unsafe fn disable_hook(target: *mut c_void) -> Result<(), MH_STATUS> {
-        Self::initialize();
+        let _state = Self::initialize()?;
 
         let status = unsafe { MH_DisableHook(target) };
         debug!("MH_DisableHook: {:?}", status);
@@ -207,6 +284,9 @@ impl MinHook {
     /// Disables all hooks.
     ///
     /// # Safety
+    ///
+    /// The caller must synchronize any code that depends on whether registered detours are
+    /// active.
     pub unsafe fn disable_all_hooks() -> Result<(), MH_STATUS> {
         unsafe { Self::disable_hook(MH_ALL_HOOKS as *mut _) }
     }
@@ -214,8 +294,11 @@ impl MinHook {
     /// Removes a hook for the target function.
     ///
     /// # Safety
+    ///
+    /// `target` must identify a hook created by MinHook. No thread may subsequently call the
+    /// trampoline returned when that hook was created.
     pub unsafe fn remove_hook(target: *mut c_void) -> Result<(), MH_STATUS> {
-        Self::initialize();
+        let _state = Self::initialize()?;
 
         let status = unsafe { MH_RemoveHook(target) };
         debug!("MH_RemoveHook: {:?}", status);
@@ -228,8 +311,11 @@ impl MinHook {
     /// Queues a hook for enabling.
     ///
     /// # Safety
+    ///
+    /// `target` must identify a hook created by MinHook. The caller must ensure that activating
+    /// the detour will be sound when the queued operation is applied.
     pub unsafe fn queue_enable_hook(target: *mut c_void) -> Result<(), MH_STATUS> {
-        Self::initialize();
+        let _state = Self::initialize()?;
 
         let status = unsafe { MH_QueueEnableHook(target) };
         debug!("MH_QueueEnableHook: {:?}", status);
@@ -242,8 +328,11 @@ impl MinHook {
     /// Queues a hook for disabling.
     ///
     /// # Safety
+    ///
+    /// `target` must identify a hook created by MinHook. The caller must synchronize any code
+    /// that depends on whether the detour is active when the queued operation is applied.
     pub unsafe fn queue_disable_hook(target: *mut c_void) -> Result<(), MH_STATUS> {
-        Self::initialize();
+        let _state = Self::initialize()?;
 
         let status = unsafe { MH_QueueDisableHook(target) };
         debug!("MH_QueueDisableHook: {:?}", status);
@@ -256,8 +345,11 @@ impl MinHook {
     /// Applies all queued hooks.
     ///
     /// # Safety
+    ///
+    /// The caller must satisfy the safety requirements of every queued enable or disable
+    /// operation and synchronize code that can execute the affected functions.
     pub unsafe fn apply_queued() -> Result<(), MH_STATUS> {
-        Self::initialize();
+        let _state = Self::initialize()?;
 
         let status = unsafe { MH_ApplyQueued() };
         debug!("MH_ApplyQueued: {:?}", status);

--- a/tests/create_hook_api.rs
+++ b/tests/create_hook_api.rs
@@ -23,7 +23,7 @@ fn test_create_hook_api() {
         assert_eq!(std::process::id(), 42);
 
         // Transmute the original function address to a function pointer to make it callable
-        let original_fn: fn() -> u32 = std::mem::transmute(original);
+        let original_fn: unsafe extern "system" fn() -> u32 = std::mem::transmute(original);
 
         // Call the original function using the original function pointer
         assert_eq!(original_fn(), original_pid);
@@ -35,7 +35,7 @@ fn test_create_hook_api() {
         assert_eq!(std::process::id(), original_pid);
     }
 
-    fn get_current_process_id_hook() -> u32 {
+    unsafe extern "system" fn get_current_process_id_hook() -> u32 {
         42
     }
 }

--- a/tests/create_hook_api_ex.rs
+++ b/tests/create_hook_api_ex.rs
@@ -26,7 +26,7 @@ fn test_create_hook_api_ex() {
         assert_eq!(std::process::id(), 42);
 
         // Transmute the original function address to a function pointer to make it callable
-        let original_fn: fn() -> u32 = std::mem::transmute(original);
+        let original_fn: unsafe extern "system" fn() -> u32 = std::mem::transmute(original);
 
         // Call the original function using the original function pointer
         assert_eq!(original_fn(), original_pid);
@@ -38,7 +38,7 @@ fn test_create_hook_api_ex() {
         MinHook::remove_hook(target).unwrap();
     }
 
-    fn get_current_process_id_hook() -> u32 {
+    unsafe extern "system" fn get_current_process_id_hook() -> u32 {
         42
     }
 }

--- a/tests/create_hook_api_with_argument.rs
+++ b/tests/create_hook_api_with_argument.rs
@@ -1,0 +1,33 @@
+use minhook::MinHook;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn Sleep(milliseconds: u32);
+}
+
+static DETOUR_CALLED: AtomicBool = AtomicBool::new(false);
+
+unsafe extern "system" fn sleep_hook(_milliseconds: u32) {
+    DETOUR_CALLED.store(true, Ordering::SeqCst);
+}
+
+#[test]
+fn test_create_hook_api_with_system_abi_argument() {
+    unsafe {
+        let (original, target) =
+            MinHook::create_hook_api_ex("kernel32.dll", "Sleep", sleep_hook as _).unwrap();
+        let original: unsafe extern "system" fn(u32) = std::mem::transmute(original);
+
+        MinHook::enable_hook(target).unwrap();
+        Sleep(0);
+        assert!(DETOUR_CALLED.swap(false, Ordering::SeqCst));
+
+        // Calling the trampoline must preserve the same system ABI and bypass the detour.
+        original(0);
+        assert!(!DETOUR_CALLED.load(Ordering::SeqCst));
+
+        MinHook::disable_hook(target).unwrap();
+        MinHook::remove_hook(target).unwrap();
+    }
+}

--- a/tests/enable_and_disable_hook.rs
+++ b/tests/enable_and_disable_hook.rs
@@ -3,6 +3,9 @@ use minhook::MinHook;
 #[test]
 fn test_hook() {
     unsafe {
+        let test_fn = std::hint::black_box(test_fn as fn() -> i32);
+        let test_fn_hook = std::hint::black_box(test_fn_hook as fn() -> i32);
+
         MinHook::create_hook(test_fn as _, test_fn_hook as _).unwrap();
 
         // Test that the hook is enabled.
@@ -14,10 +17,12 @@ fn test_hook() {
         assert_eq!(test_fn(), 0);
     }
 
+    #[inline(never)]
     fn test_fn() -> i32 {
         0
     }
 
+    #[inline(never)]
     fn test_fn_hook() -> i32 {
         1
     }

--- a/tests/external_initialization.rs
+++ b/tests/external_initialization.rs
@@ -1,0 +1,20 @@
+use minhook::{MH_STATUS, MinHook};
+
+unsafe extern "system" {
+    fn MH_Initialize() -> MH_STATUS;
+    fn MH_Uninitialize() -> MH_STATUS;
+}
+
+#[test]
+fn wrapper_does_not_uninitialize_an_external_owner() {
+    unsafe {
+        assert_eq!(MH_Initialize(), MH_STATUS::MH_OK);
+
+        // The wrapper observes an already initialized native library and borrows it.
+        MinHook::enable_all_hooks().unwrap();
+        MinHook::uninitialize().unwrap();
+
+        // If the wrapper had torn down borrowed state, this would report NOT_INITIALIZED.
+        assert_eq!(MH_Uninitialize(), MH_STATUS::MH_OK);
+    }
+}

--- a/tests/hook_queue.rs
+++ b/tests/hook_queue.rs
@@ -4,6 +4,11 @@ use std::ffi::c_void;
 #[test]
 fn test_hooks_queue() {
     unsafe {
+        let test_fn1 = std::hint::black_box(test_fn1 as FnType1);
+        let test_fn1_hook = std::hint::black_box(test_fn1_hook as FnType1);
+        let test_fn2 = std::hint::black_box(test_fn2 as FnType2);
+        let test_fn2_hook = std::hint::black_box(test_fn2_hook as FnType2);
+
         MinHook::create_hook(
             test_fn1 as FnType1 as *mut c_void,
             test_fn1_hook as FnType1 as *mut c_void,
@@ -37,18 +42,22 @@ fn test_hooks_queue() {
     type FnType1 = fn() -> i32;
     type FnType2 = fn(i32) -> i32;
 
+    #[inline(never)]
     fn test_fn1() -> i32 {
         0
     }
 
+    #[inline(never)]
     fn test_fn1_hook() -> i32 {
         1
     }
 
+    #[inline(never)]
     fn test_fn2(x: i32) -> i32 {
         x
     }
 
+    #[inline(never)]
     fn test_fn2_hook(x: i32) -> i32 {
         x + 1
     }

--- a/tests/initialize_and_uninitialize.rs
+++ b/tests/initialize_and_uninitialize.rs
@@ -3,7 +3,13 @@ use minhook::MinHook;
 #[test]
 fn test_hook() {
     // Minhook will automatically be initialized, so there is no need to ever call initialize().
-    // However, we can call uninitialize() when we are done with MinHook.
-    // It is not unsafe to call uninitialize(), even multiple times, but it will only uninitialize MinHook once.
-    MinHook::uninitialize();
+    // We can explicitly uninitialize it once all detours and trampolines are no longer in use.
+    unsafe {
+        MinHook::enable_all_hooks().unwrap();
+        MinHook::uninitialize().unwrap();
+
+        // A later operation reinitializes MinHook instead of being stuck in an uninitialized state.
+        MinHook::enable_all_hooks().unwrap();
+        MinHook::uninitialize().unwrap();
+    }
 }

--- a/tests/initialize_and_uninitialize.rs
+++ b/tests/initialize_and_uninitialize.rs
@@ -7,9 +7,5 @@ fn test_hook() {
     unsafe {
         MinHook::enable_all_hooks().unwrap();
         MinHook::uninitialize().unwrap();
-
-        // A later operation reinitializes MinHook instead of being stuck in an uninitialized state.
-        MinHook::enable_all_hooks().unwrap();
-        MinHook::uninitialize().unwrap();
     }
 }

--- a/tests/reinitialize_after_uninitialize.rs
+++ b/tests/reinitialize_after_uninitialize.rs
@@ -1,0 +1,26 @@
+use minhook::{MH_STATUS, MinHook};
+
+unsafe extern "system" {
+    fn MH_Initialize() -> MH_STATUS;
+    fn MH_Uninitialize() -> MH_STATUS;
+}
+
+#[test]
+fn wrapper_reinitializes_native_minhook_after_uninitialize() {
+    unsafe {
+        // A public wrapper operation performs the first native initialization.
+        MinHook::enable_all_hooks().unwrap();
+        MinHook::uninitialize().unwrap();
+
+        // Native MinHook confirms that the wrapper completely uninitialized it.
+        assert_eq!(MH_Uninitialize(), MH_STATUS::MH_ERROR_NOT_INITIALIZED);
+
+        // A subsequent wrapper operation must initialize the native library again.
+        MinHook::enable_all_hooks().unwrap();
+
+        // Native MinHook confirms that it is initialized for the second time.
+        assert_eq!(MH_Initialize(), MH_STATUS::MH_ERROR_ALREADY_INITIALIZED);
+
+        MinHook::uninitialize().unwrap();
+    }
+}

--- a/tests/trampoline_enable_and_disable_hook.rs
+++ b/tests/trampoline_enable_and_disable_hook.rs
@@ -5,6 +5,9 @@ use std::mem;
 #[test]
 fn test_hook_trampoline_enable_and_disable_hook() {
     unsafe {
+        let test_fn_trampoline_orig = std::hint::black_box(test_fn_trampoline_orig as FnType);
+        let test_fn_trampoline_hook = std::hint::black_box(test_fn_trampoline_hook as FnType);
+
         // Create a hook for `test_fn_trampoline_orig`
         let trampoline =
             MinHook::create_hook(test_fn_trampoline_orig as _, test_fn_trampoline_hook as _)
@@ -27,10 +30,12 @@ fn test_hook_trampoline_enable_and_disable_hook() {
     type FnType = fn(i32) -> i32;
     static TRAMPOLINE: OnceCell<FnType> = OnceCell::new();
 
+    #[inline(never)]
     fn test_fn_trampoline_orig(x: i32) -> i32 {
         x
     }
 
+    #[inline(never)]
     fn test_fn_trampoline_hook(_x: i32) -> i32 {
         // Set a value that we want to return for the test.
         let val = 42;


### PR DESCRIPTION
## What changed

This PR fixes three correctness and safety problems found while reviewing the wrapper.

### 1. Make Rust-function hooks work in optimized builds

**Problem:** The README and integration tests called locally defined Rust functions directly. In release builds, the optimizer could constant-fold or otherwise bypass the patched entry point, so MinHook reported success while the original function still ran.

**Solution:**
- keep example/test targets out of line with `#[inline(never)]`
- call them through function pointers passed through `std::hint::black_box`
- run the integration suite in both debug and release profiles

**Why this solves it:** The opaque indirect call must go through the function address that MinHook patched, instead of allowing the compiler to replace the call with a known result. The previously failing release tests now pass on both x64 and i686.

### 2. Enforce and test the correct Win32 calling convention

**Problem:** The API-hook tests used Rust-ABI `fn` pointers for Win32 functions. That happened to work for the zero-argument `GetCurrentProcessId` test, but a Win32 function with stack arguments crashes on 32-bit Windows because `extern "system"` uses the platform system calling convention.

**Solution:**
- change Win32 detours and trampoline types to `extern "system"`
- add a regression test that hooks `Sleep(u32)`, invokes its trampoline, and runs on i686
- document signature, ABI, unwind, module-lifetime, and trampoline-lifetime requirements on every unsafe API
- add x64/i686 CI coverage

**Why this solves it:** Detours and trampolines now use the same ABI as the target API, including the 32-bit Windows stack-cleanup convention. The argument-bearing regression test passes on both architectures and would catch the previous mismatch.

### 3. Make initialization ownership and teardown explicit

**Problem:** Two independent `Once` values made teardown irreversible, initialization failures panic, and `uninitialize()` safe even though native teardown invalidates trampoline memory. The wrapper also treated `MH_ERROR_ALREADY_INITIALIZED` as success and could later tear down a MinHook instance owned by another component.

**Solution:**
- replace the `Once` values with a mutex-protected lifecycle state
- track whether initialization is wrapper-owned or externally owned
- serialize wrapper API transitions and return initialization errors through the existing `Result` APIs
- make `uninitialize()` unsafe and fallible
- permit clean reinitialization after wrapper-owned teardown
- leave externally owned MinHook state running
- add regression tests for reinitialization and external ownership

**Why this solves it:** Teardown can no longer happen through a safe API without acknowledging trampoline-lifetime requirements, native failures are returned instead of panicking, and the wrapper only calls native `MH_Uninitialize` for initialization it owns.

## API impact

`MinHook::uninitialize()` is now:

```rust
pub unsafe fn uninitialize() -> Result<(), MH_STATUS>
```

This is an intentional breaking change because callers must prove that no detour or trampoline remains in use before native executable buffers are freed.

## Validation

- `cargo fmt --all -- --check`
- Clippy with `-D clippy::all` on x64 and i686
- all integration tests on:
  - x64 debug
  - x64 release
  - i686 debug
  - i686 release
- doctests in debug and release, including i686 release
